### PR TITLE
feat: `RequestTelemetry` mutable timestamp

### DIFF
--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -115,6 +115,11 @@ impl RequestTelemetry {
         &mut self.measurements
     }
 
+    /// Returns mutable reference to the timestamp.
+    pub fn timestamp_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
     /// Returns an indication of successful or unsuccessful call.
     pub fn is_success(&self) -> bool {
         if let Ok(response_code) = StatusCode::from_str(&self.response_code) {


### PR DESCRIPTION
Add functionality for specifying the timestamp of a `RequestTelemetry`, instead of always using `Utc::now()`.

This enables setting the timestamp of the request to e.g. when the request was received, instead of when the telemetry item was submitted (which normally would be when the request processing was finished).