### PR TITLE
refactor: request telemetry name != URI

### DIFF
--- a/appinsights/src/blocking/mod.rs
+++ b/appinsights/src/blocking/mod.rs
@@ -103,8 +103,8 @@ impl TelemetryClient {
     }
 
     /// Logs a HTTP request with the specified method, URL, duration and response code.
-    pub fn track_request(&self, method: Method, uri: Uri, duration: Duration, response_code: impl Into<String>) {
-        let event = RequestTelemetry::new(method, uri, duration, response_code);
+    pub fn track_request(&self, name: String, uri: Uri, duration: Duration, response_code: impl Into<String>) {
+        let event = RequestTelemetry::new(name, uri, duration, response_code);
         self.track(event)
     }
 

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use http::{Method, Uri};
+use http::Uri;
 
 use crate::{
     channel::{InMemoryChannel, TelemetryChannel},
@@ -146,7 +146,7 @@ impl TelemetryClient {
         self.track(event)
     }
 
-    /// Logs a HTTP request with the specified method, URL, duration and response code.
+    /// Logs a HTTP request with the specified name, URL, duration and response code.
     ///
     /// # Examples
     ///
@@ -159,8 +159,8 @@ impl TelemetryClient {
     /// let uri: Uri = "https://api.github.com/dmolokanov/appinsights-rs".parse().unwrap();
     /// client.track_request(Method::GET, uri, Duration::from_millis(100), "200");
     /// ```
-    pub fn track_request(&self, method: Method, uri: Uri, duration: Duration, response_code: impl Into<String>) {
-        let event = RequestTelemetry::new(method, uri, duration, response_code);
+    pub fn track_request(&self, name: String, uri: Uri, duration: Duration, response_code: impl Into<String>) {
+        let event = RequestTelemetry::new(name, uri, duration, response_code);
         self.track(event)
     }
 

--- a/appinsights/tests/telemetry.rs
+++ b/appinsights/tests/telemetry.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use appinsights::{telemetry::SeverityLevel, TelemetryClient};
-use hyper::{Method, Uri};
+use hyper::Uri;
 
 async fn panicking(message: &'static str) {
     panic!("{}", message);
@@ -27,7 +27,7 @@ async fn it_tracks_all_telemetry_items() {
         .track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
     ai.lock().unwrap().track_metric("gateway_latency_ms", 113.0);
     ai.lock().unwrap().track_request(
-        Method::GET,
+        "GET /dmolokanov/appinsights-rs".to_string(),
         "https://api.github.com/dmolokanov/appinsights-rs"
             .parse::<Uri>()
             .unwrap(),

--- a/appinsights/tests/telemetry_blocking.rs
+++ b/appinsights/tests/telemetry_blocking.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use appinsights::{blocking::TelemetryClient, telemetry::SeverityLevel};
-use hyper::{Method, Uri};
+use hyper::Uri;
 
 #[test]
 fn it_tracks_all_telemetry_items() {
@@ -21,7 +21,7 @@ fn it_tracks_all_telemetry_items() {
     ai.track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
     ai.track_metric("gateway_latency_ms", 113.0);
     ai.track_request(
-        Method::GET,
+        "GET /dmolokanov/appinsights-rs".to_string(),
         "https://api.github.com/dmolokanov/appinsights-rs"
             .parse::<Uri>()
             .unwrap(),


### PR DESCRIPTION
According to the App Insights data model, the `Name` attribute of a [Request Telemetry](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete#name) should typically be on the form `<method> <URL path template>`.

This PR changes the behaviour from using the full URI for the name, i.e. `GET https://aws.com/login/12315dgf-4234`, to using a custom name that should be on the form `GET /login/{user_id}`.

Also includes a fix to use the full path and query parameters for the URI field,
not just the path.