### PR TITLE
feat: `RemoteDependencyTelemetry` mutable timestamp

### DIFF
--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -115,6 +115,11 @@ impl RemoteDependencyTelemetry {
         &mut self.measurements
     }
 
+    /// Returns mutable reference to the timestamp.
+    pub fn timestamp_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
     /// Sets the dependency id. Use this to link other telemetry to this dependency by setting their operation
     /// parent id to this id.
     ///


### PR DESCRIPTION
Add functionality for specifying the timestamp of a `RemoteDependencyTelemetry`, instead of always using `Utc::now()`.

This enables setting the timestamp of the request to e.g. when the dependency call was initiated, instead of when the telemetry item was submitted (which normally would be when the dependency processing was finished).