### PR TITLE
feat: `ExceptionTelemetry` mutable timestamp

### DIFF
--- a/appinsights/src/telemetry/exception.rs
+++ b/appinsights/src/telemetry/exception.rs
@@ -107,6 +107,11 @@ impl ExceptionTelemetry {
         self
     }
 
+    /// Returns mutable reference to the timestamp.
+    pub fn timestamp_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
     /// Create a new [ExceptionTelemetryBuilder], used to construct an [ExceptionTelemetry].
     pub fn builder() -> ExceptionTelemetryBuilder {
         ExceptionTelemetryBuilder::default()


### PR DESCRIPTION
Add functionality for specifying the timestamp of a `ExceptionTelemetry`, instead of always using `Utc::now()`.

Useful as preparing all the metadata that will be sent with the exception, such as a stacktrace, might take a considerable amount of time. The timestamp of the telemetry item will then have a significant offset compared to the timestamp of when the event actually occurred.