### PR TITLE
feat: configurable timestamp format

### DIFF
--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -93,9 +93,11 @@ impl TelemetryClient {
     /// let mut client = TelemetryClient::new("<instrumentation key>".to_string());
     /// client.context_mut().tags_mut().insert("app_version".into(), "v0.1.1".to_string());
     /// client.context_mut().properties_mut().insert("Resource Group".into(), "my-rg".to_string());
+    /// *client.context_mut().timestamp_format() = SecondsFormat::Seconds;
     ///
     /// assert_eq!(client.context().tags().get("app_version"), Some(&"v0.1.1".to_string()));
     /// assert_eq!(client.context().properties().get("Resource Group"), Some(&"my-rg".to_string()));
+    /// assert_eq!(client.context().timestamp_format(), SecondsFormat::Seconds);
     /// ```
     pub fn context_mut(&mut self) -> &mut TelemetryContext {
         &mut self.context
@@ -140,7 +142,7 @@ impl TelemetryClient {
     /// # use appinsights::telemetry::SeverityLevel;
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
     /// client.track_metric("gateway_latency_ms", 113.0);
-    /// ```    
+    /// ```
     pub fn track_metric(&self, name: impl Into<String>, value: f64) {
         let event = MetricTelemetry::new(name, value);
         self.track(event)

--- a/appinsights/src/config.rs
+++ b/appinsights/src/config.rs
@@ -1,6 +1,8 @@
 //! Module for telemetry client configuration.
 use std::time::Duration;
 
+use chrono::SecondsFormat;
+
 /// Configuration data used to initialize a new [`TelemetryClient`](../struct.TelemetryClient.html) with.
 ///
 /// # Examples
@@ -30,6 +32,9 @@ pub struct TelemetryConfig {
 
     /// Maximum time to wait until send a batch of telemetry.
     interval: Duration,
+
+    /// Timestamp format for telemetry data.
+    timestamp_format: SecondsFormat,
 }
 
 impl TelemetryConfig {
@@ -57,6 +62,11 @@ impl TelemetryConfig {
     pub fn interval(&self) -> Duration {
         self.interval
     }
+
+    /// Returns timestamp format for telemetry data.
+    pub fn timestamp_format(&self) -> SecondsFormat {
+        self.timestamp_format
+    }
 }
 
 /// Constructs a new instance of a [`TelemetryConfig`](struct.TelemetryConfig.html) with required
@@ -74,6 +84,7 @@ impl DefaultTelemetryConfigBuilder {
             i_key: i_key.into(),
             endpoint: "https://dc.services.visualstudio.com/v2/track".into(),
             interval: Duration::from_secs(2),
+            timestamp_format: SecondsFormat::Millis,
         }
     }
 }
@@ -83,6 +94,7 @@ pub struct TelemetryConfigBuilder {
     i_key: String,
     endpoint: String,
     interval: Duration,
+    timestamp_format: SecondsFormat,
 }
 
 impl TelemetryConfigBuilder {
@@ -110,12 +122,19 @@ impl TelemetryConfigBuilder {
         self
     }
 
+    /// Initializes a builder with a format for the event timestamp in telemetry data.
+    pub fn timestamp_format(mut self, format: SecondsFormat) -> Self {
+        self.timestamp_format = format;
+        self
+    }
+
     /// Constructs a new instance of a [`TelemetryConfig`](struct.TelemetryConfig.html) with custom settings.
     pub fn build(self) -> TelemetryConfig {
         TelemetryConfig {
             i_key: self.i_key,
             endpoint: self.endpoint,
             interval: self.interval,
+            timestamp_format: self.timestamp_format,
         }
     }
 }
@@ -132,7 +151,8 @@ mod tests {
             TelemetryConfig {
                 i_key: "instrumentation key".into(),
                 endpoint: "https://dc.services.visualstudio.com/v2/track".into(),
-                interval: Duration::from_secs(2)
+                interval: Duration::from_secs(2),
+                timestamp_format: SecondsFormat::Millis,
             },
             config
         )
@@ -144,13 +164,15 @@ mod tests {
             .i_key("instrumentation key")
             .endpoint("https://google.com")
             .interval(Duration::from_micros(100))
+            .timestamp_format(SecondsFormat::Secs)
             .build();
 
         assert_eq!(
             TelemetryConfig {
                 i_key: "instrumentation key".into(),
                 endpoint: "https://google.com".into(),
-                interval: Duration::from_micros(100)
+                interval: Duration::from_micros(100),
+                timestamp_format: SecondsFormat::Secs,
             },
             config
         );

--- a/appinsights/src/lib.rs
+++ b/appinsights/src/lib.rs
@@ -51,6 +51,7 @@
 //! [`TelemetryClient`](struct.TelemetryClient.html) with it.
 //!
 //! ```rust
+//! use chrono::SecondsFormat;
 //! use std::time::Duration;
 //! use appinsights::{TelemetryClient, TelemetryConfig};
 //! use appinsights::telemetry::SeverityLevel;
@@ -61,10 +62,12 @@
 //!     .i_key("<instrumentation key>")
 //!     // set a new maximum time to wait until data will be sent to the server
 //!     .interval(Duration::from_secs(5))
+//!     // set the format of event timestamps
+//!     .timestamp_format(SecondsFormat::Micros)
 //!     // construct a new instance of telemetry configuration
 //!     .build();
 //!
-//! // configure telemetry client with default settings
+//! // configure telemetry client with the custom settings
 //! let client = TelemetryClient::from_config(config);
 //!
 //! // send trace telemetry to the Application Insights server

--- a/appinsights/src/telemetry/availability.rs
+++ b/appinsights/src/telemetry/availability.rs
@@ -1,6 +1,6 @@
 use std::time::Duration as StdDuration;
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -127,7 +127,7 @@ impl From<(TelemetryContext, AvailabilityTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, AvailabilityTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Availability".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::AvailabilityData(AvailabilityData {
@@ -153,7 +153,7 @@ impl From<(TelemetryContext, AvailabilityTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
 
@@ -161,8 +161,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -206,8 +210,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/event.rs
+++ b/appinsights/src/telemetry/event.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -98,7 +98,7 @@ impl From<(TelemetryContext, EventTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, EventTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Event".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::EventData(EventData {
@@ -116,7 +116,7 @@ impl From<(TelemetryContext, EventTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
     use crate::time;
@@ -125,8 +125,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 600));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -166,8 +170,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/exception.rs
+++ b/appinsights/src/telemetry/exception.rs
@@ -1,6 +1,6 @@
 // TODO implement exception collection telemetry item
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     contracts::{Base, Data, Envelope, ExceptionData, ExceptionDetails},
@@ -144,7 +144,7 @@ impl From<(TelemetryContext, ExceptionTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, ExceptionTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Exception".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::ExceptionData(ExceptionData {

--- a/appinsights/src/telemetry/metric/aggregation.rs
+++ b/appinsights/src/telemetry/metric/aggregation.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -100,7 +100,7 @@ impl From<(TelemetryContext, AggregateMetricTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, AggregateMetricTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Metric".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::MetricData(MetricData {
@@ -126,7 +126,7 @@ impl From<(TelemetryContext, AggregateMetricTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
     use crate::time;
@@ -135,8 +135,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 100));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -180,8 +184,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 101));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/metric/measurement.rs
+++ b/appinsights/src/telemetry/metric/measurement.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -87,7 +87,7 @@ impl From<(TelemetryContext, MetricTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, MetricTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Metric".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::MetricData(MetricData {
@@ -110,7 +110,7 @@ impl From<(TelemetryContext, MetricTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
     use crate::time;
@@ -119,8 +119,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 100));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -160,8 +164,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 101));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/page_view.rs
+++ b/appinsights/src/telemetry/page_view.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 use http::Uri;
 
 use crate::{
@@ -118,7 +118,7 @@ impl From<(TelemetryContext, PageViewTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, PageViewTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.PageView".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::PageViewData(PageViewData {
@@ -143,7 +143,7 @@ impl From<(TelemetryContext, PageViewTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
 
@@ -151,8 +151,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -193,8 +197,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -1,6 +1,6 @@
 use std::time::Duration as StdDuration;
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -204,7 +204,7 @@ impl From<(TelemetryContext, RemoteDependencyTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, RemoteDependencyTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.RemoteDependency".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::RemoteDependencyData(RemoteDependencyData {
@@ -229,7 +229,7 @@ impl From<(TelemetryContext, RemoteDependencyTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
 
@@ -237,7 +237,12 @@ mod tests {
     fn it_uses_specified_id() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let context = TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         let mut telemetry = RemoteDependencyTelemetry::new(
             "GET https://example.com/main.html",
             "HTTP",
@@ -275,8 +280,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -326,8 +335,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, time::Duration as StdDuration};
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 use http::{StatusCode, Uri};
 
 use crate::{
@@ -201,7 +201,7 @@ impl From<(TelemetryContext, RequestTelemetry)> for Envelope {
         let success = telemetry.is_success();
         Self {
             name: "Microsoft.ApplicationInsights.Request".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::RequestData(RequestData {
@@ -225,7 +225,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
     use http::Method;
 
     use super::*;
@@ -237,7 +237,12 @@ mod tests {
         uuid::set(Uuid::from_str("910b414a-f368-4b3a-aff6-326632aac566").unwrap());
 
         let id = "specified-id".to_string();
-        let context = TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         let method = Method::GET;
         let uri: Uri = "https://example.com/main.html".parse().unwrap();
         let name = format!("{method} {}", uri.path());
@@ -277,8 +282,12 @@ mod tests {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
         uuid::set(Uuid::from_str("910b414a-f368-4b3a-aff6-326632aac566").unwrap());
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -331,8 +340,12 @@ mod tests {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
         uuid::set(Uuid::from_str("910b414a-f368-4b3a-aff6-326632aac566").unwrap());
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -174,7 +174,7 @@ impl From<(TelemetryContext, TraceTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, TraceTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Message".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::MessageData(MessageData {
@@ -193,7 +193,7 @@ impl From<(TelemetryContext, TraceTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::{TimeZone, Utc};
+    use chrono::{SecondsFormat, TimeZone, Utc};
 
     use super::{SeverityLevel, TraceTelemetry};
     use crate::{
@@ -206,8 +206,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -248,8 +252,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 


### PR DESCRIPTION
Add the ability to configure the format of event timestamps sent to appinsights. The `timestamp_format: chrono::SecondsFormat` can now be set on the `TelemetryConfig` struct (and passed on to the `TelemetryContext` struct), which will then be used when generating the string representation of all event timestamps.

TL;DR: allows setting the precision of timestamp events, which enables sub-millisecond precision.