### PR TITLE
feat: add timeout to reqwest client sending telemtry items

### DIFF
--- a/appinsights/src/channel/state.rs
+++ b/appinsights/src/channel/state.rs
@@ -3,7 +3,7 @@ use std::{mem, sync::Arc, time::Duration};
 use crossbeam_queue::SegQueue;
 use futures_channel::mpsc::UnboundedReceiver;
 use futures_util::{Future, Stream, StreamExt};
-use log::{debug, error, trace};
+use log::{debug, error, info, trace};
 use sm::{sm, Event};
 
 use crate::{
@@ -85,6 +85,7 @@ impl Worker {
         let mut items: Vec<Envelope> = Default::default();
         let mut retry = Retry::default();
 
+        info!("serving worker in infinite state-machine loop");
         loop {
             state = match state {
                 InitialReceiving(m) => self.handle_receiving(m, &mut items).await,

--- a/appinsights/src/transmitter.rs
+++ b/appinsights/src/transmitter.rs
@@ -25,7 +25,10 @@ pub struct Transmitter {
 impl Transmitter {
     /// Creates a new instance of telemetry items sender.
     pub fn new(url: &str) -> Self {
-        let client = Client::new();
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap();
         Self {
             url: url.into(),
             client,


### PR DESCRIPTION
We are observing stalled telemetry submissions, and have weeded it down to the telemetry client unable to continue after issuing a send operation.

We can observe from console logs the following:
```
Timeout expired
Sending 42 telemetry items triggered by TimeoutExpired 
```

Expecting an line with the following on success: `Successfully sent 42 items`. This line never arrives.
